### PR TITLE
[FEAT] urql: remove auth headers for hasura

### DIFF
--- a/frontend/src/boot/graphql-client.ts
+++ b/frontend/src/boot/graphql-client.ts
@@ -61,12 +61,6 @@ export function createUrqlClient() {
       mapExchange(loadingBarTriggers),
       fetchExchange,
     ],
-    fetchOptions: {
-      headers: {
-        // TODO: implement proper authentication
-        'x-hasura-admin-secret': 'changeForProduction',
-      },
-    },
   });
 }
 


### PR DESCRIPTION
Removes the `x-hasura-admin-secret` header so hasura will rely on cookie authentication.

Not tested, as we don't yet have the necessary common gateway, so hasura and the frontend use the same port.