### PR TITLE
[FEAT] handle disabled orchards

### DIFF
--- a/frontend/src/components/Entity/Edit/EntitySelect.vue
+++ b/frontend/src/components/Entity/Edit/EntitySelect.vue
@@ -10,6 +10,7 @@
       autocomplete="off"
       :option-value="optionValueKey"
       :option-label="optionLabelKey"
+      :option-disable="optionDisable"
       dense
       outlined
       use-input
@@ -41,7 +42,7 @@
 
 <script setup lang="ts" generic="T extends { [key: string]: any }">
 import BaseGraphqlError from 'src/components/Base/BaseGraphqlError.vue';
-import { QSelect, QSelectSlots } from 'quasar';
+import { QSelect, QSelectSlots, QSelectProps } from 'quasar';
 import { useI18n } from 'src/composables/useI18n';
 import { ComponentPublicInstance, VNodeRef, computed, ref } from 'vue';
 import { useInputBackground } from 'src/composables/useInputBackground';
@@ -79,6 +80,7 @@ export interface EntitySelectPropsWithoutModel<T> {
   loading?: boolean;
   error?: CombinedError | null;
   clearable?: boolean;
+  optionDisable?: QSelectProps['optionDisable'];
 }
 
 const props = withDefaults(defineProps<EntitySelectPropsWithoutModel<T>>(), {
@@ -86,6 +88,7 @@ const props = withDefaults(defineProps<EntitySelectPropsWithoutModel<T>>(), {
   loading: false,
   error: null,
   clearable: true,
+  optionDisable: undefined,
 });
 
 const selectRef = ref<QSelect | null>(null);

--- a/frontend/src/components/PlantRow/PlantRowEntityForm.vue
+++ b/frontend/src/components/PlantRow/PlantRowEntityForm.vue
@@ -18,6 +18,7 @@
   <OrchardSelect
     :ref="(el: InputRef) => (refs.orchardRef = el)"
     v-model="data.orchard_id"
+    :with-disabled="props.plantRow.orchard?.disabled"
   />
   <EntityInput
     :ref="(el: InputRef) => (refs.dateEliminatedRef = el)"

--- a/frontend/src/components/PlantRow/plantRowFragment.ts
+++ b/frontend/src/components/PlantRow/plantRowFragment.ts
@@ -11,6 +11,7 @@ export const plantRowFragment = graphql(`
     orchard {
       id
       name
+      disabled
     }
     created
     modified


### PR DESCRIPTION
Hides disabled orchards from the orchard select by default.

Disabled orchards are however shown, if a plant row with a disabled orchard is edited. It is however not possible to select a disabled orchard. So either you leave the field untouched or you change it to a enabled orchard.