### PR TITLE
[REFACTOR] Cleanup fragments

### DIFF
--- a/frontend/src/components/Analyze/Result/AnalyzeResultTableCellAttributionOverlay.vue
+++ b/frontend/src/components/Analyze/Result/AnalyzeResultTableCellAttributionOverlay.vue
@@ -43,8 +43,7 @@ const query = graphql(
   `
     query AnalyzeResultTableCellAttributionDetails(
       $id: Int!
-      $withAttributions: Boolean! = false
-      $withSegments: Boolean! = true
+      $PlantWithSegments: Boolean! = true
     ) {
       attributions_view(where: { id: { _eq: $id } }) {
         ...entityAttributionsViewFragment

--- a/frontend/src/components/Crossing/CrossingModalEdit.vue
+++ b/frontend/src/components/Crossing/CrossingModalEdit.vue
@@ -42,21 +42,9 @@ import { useI18n } from 'vue-i18n';
 export type CrossingEditInput = Omit<CrossingFragment, 'created' | 'modified'>;
 export type CrossingInsertInput = Omit<
   CrossingEditInput,
-  | 'id'
-  | 'mother_cultivar_id'
-  | 'father_cultivar_id'
-  | 'mother_cultivar'
-  | 'father_cultivar'
+  'id' | 'mother_cultivar_id' | 'father_cultivar_id'
 > &
-  Partial<
-    Pick<
-      CrossingEditInput,
-      | 'mother_cultivar_id'
-      | 'father_cultivar_id'
-      | 'mother_cultivar'
-      | 'father_cultivar'
-    >
-  >;
+  Partial<Pick<CrossingEditInput, 'mother_cultivar_id' | 'father_cultivar_id'>>;
 
 export interface CrossingModalEditProps {
   crossing: CrossingEditInput | CrossingInsertInput;
@@ -68,10 +56,7 @@ const insertMutation = graphql(
   `
     mutation InsertCrossing(
       $entity: crossings_insert_input!
-      $withParentCultivar: Boolean = false
-      $withLot: Boolean = false
-      $withLots: Boolean = false
-      $withMotherPlants: Boolean = false
+      $CultivarWithLot: Boolean = false
     ) {
       insert_crossings_one(object: $entity) {
         ...crossingFragment
@@ -88,10 +73,7 @@ const editMutation = graphql(
     mutation UpdateCrossing(
       $id: Int!
       $entity: crossings_set_input!
-      $withParentCultivar: Boolean = false
-      $withLot: Boolean = false
-      $withLots: Boolean = false
-      $withMotherPlants: Boolean = false
+      $CultivarWithLot: Boolean = false
     ) {
       update_crossings_by_pk(pk_columns: { id: $id }, _set: $entity) {
         ...crossingFragment

--- a/frontend/src/components/Crossing/crossingFragment.ts
+++ b/frontend/src/components/Crossing/crossingFragment.ts
@@ -1,33 +1,15 @@
 import { graphql, type FragmentOf } from 'src/graphql';
-import { cultivarFragment } from '../Cultivar/cultivarFragment';
-import { lotFragment } from '../Lot/lotFragment';
 
 export type CrossingFragment = FragmentOf<typeof crossingFragment>;
 
-export const crossingFragment = graphql(
-  `
-    fragment crossingFragment on crossings @_unmask {
-      id
-      name
-      note
-      created
-      modified
-      mother_cultivar_id
-      mother_cultivar @include(if: $withParentCultivar) {
-        ...cultivarFragment
-      }
-      father_cultivar_id
-      father_cultivar @include(if: $withParentCultivar) {
-        ...cultivarFragment
-      }
-      lots @include(if: $withLots) {
-        ...lotFragment
-      }
-      mother_plants @include(if: $withMotherPlants) {
-        id
-        name
-      }
-    }
-  `,
-  [cultivarFragment, lotFragment],
-);
+export const crossingFragment = graphql(`
+  fragment crossingFragment on crossings @_unmask {
+    id
+    name
+    note
+    created
+    modified
+    mother_cultivar_id
+    father_cultivar_id
+  }
+`);

--- a/frontend/src/components/Cultivar/CultivarModalEdit.vue
+++ b/frontend/src/components/Cultivar/CultivarModalEdit.vue
@@ -56,7 +56,9 @@ const insertMutation = graphql(
   `
     mutation InsertCultivar(
       $entity: cultivars_insert_input!
-      $withLot: Boolean = false
+      $CultivarWithLot: Boolean = false
+      $LotWithOrchard: Boolean = false
+      $LotWithCrossing: Boolean = false
     ) {
       insert_cultivars_one(object: $entity) {
         ...cultivarFragment
@@ -73,7 +75,9 @@ const editMutation = graphql(
     mutation UpdateCultivar(
       $id: Int!
       $entity: cultivars_set_input!
-      $withLot: Boolean = false
+      $CultivarWithLot: Boolean = false
+      $LotWithOrchard: Boolean = false
+      $LotWithCrossing: Boolean = false
     ) {
       update_cultivars_by_pk(pk_columns: { id: $id }, _set: $entity) {
         ...cultivarFragment

--- a/frontend/src/components/Cultivar/cultivarFragment.ts
+++ b/frontend/src/components/Cultivar/cultivarFragment.ts
@@ -18,7 +18,7 @@ export const cultivarFragment = graphql(
       created
       modified
       lot_id
-      lot @include(if: $withLot) {
+      lot @include(if: $CultivarWithLot) {
         ...lotFragment
       }
     }

--- a/frontend/src/components/Lot/lotFragment.ts
+++ b/frontend/src/components/Lot/lotFragment.ts
@@ -1,25 +1,36 @@
 import { graphql, type FragmentOf } from 'src/graphql';
+import { crossingFragment } from '../Crossing/crossingFragment';
+import { orchardFragment } from '../Orchard/orchardFragment';
 
 export type LotFragment = FragmentOf<typeof lotFragment>;
 
-export const lotFragment = graphql(`
-  fragment lotFragment on lots @_unmask {
-    id
-    name_segment
-    full_name
-    name_override
-    display_name
-    date_sowed
-    numb_seeds_sowed
-    numb_seedlings_grown
-    seed_tray
-    date_planted
-    numb_seedlings_planted
-    plot
-    note
-    created
-    modified
-    orchard_id
-    crossing_id
-  }
-`);
+export const lotFragment = graphql(
+  `
+    fragment lotFragment on lots @_unmask {
+      id
+      name_segment
+      full_name
+      name_override
+      display_name
+      date_sowed
+      numb_seeds_sowed
+      numb_seedlings_grown
+      seed_tray
+      date_planted
+      numb_seedlings_planted
+      plot
+      note
+      created
+      modified
+      orchard_id
+      orchard @include(if: $LotWithOrchard) {
+        ...orchardFragment
+      }
+      crossing_id
+      crossing @include(if: $LotWithCrossing) {
+        ...crossingFragment
+      }
+    }
+  `,
+  [crossingFragment, orchardFragment],
+);

--- a/frontend/src/components/MotherPlant/MotherPlantModalEdit.vue
+++ b/frontend/src/components/MotherPlant/MotherPlantModalEdit.vue
@@ -74,16 +74,11 @@ const insertMutation = graphql(
   `
     mutation InsertMotherPlant(
       $entity: mother_plants_insert_input!
-      $withPlant: Boolean = false
-      $withPollen: Boolean = false
-      $withCrossing: Boolean = false
-      $withParentCultivar: Boolean = false
-      $withCultivar: Boolean = false
-      $withMotherPlants: Boolean = false
-      $withSegments: Boolean = false
-      $withAttributions: Boolean = false
-      $withLot: Boolean = false
-      $withLots: Boolean = false
+      $MotherPlantWithPlant: Boolean = false
+      $MotherPlantWithCrossing: Boolean = false
+      $PollenWithCultivar: Boolean = false
+      $PlantWithSegments: Boolean = false
+      $CultivarWithLot: Boolean = false
     ) {
       insert_mother_plants_one(object: $entity) {
         ...motherPlantFragment
@@ -100,16 +95,11 @@ const editMutation = graphql(
     mutation UpdateMotherPlant(
       $id: Int!
       $entity: mother_plants_set_input!
-      $withPlant: Boolean = false
-      $withPollen: Boolean = false
-      $withCrossing: Boolean = false
-      $withParentCultivar: Boolean = false
-      $withCultivar: Boolean = false
-      $withMotherPlants: Boolean = false
-      $withSegments: Boolean = false
-      $withAttributions: Boolean = false
-      $withLot: Boolean = false
-      $withLots: Boolean = false
+      $MotherPlantWithPlant: Boolean = false
+      $MotherPlantWithCrossing: Boolean = false
+      $PollenWithCultivar: Boolean = false
+      $PlantWithSegments: Boolean = false
+      $CultivarWithLot: Boolean = false
     ) {
       update_mother_plants_by_pk(pk_columns: { id: $id }, _set: $entity) {
         ...motherPlantFragment

--- a/frontend/src/components/MotherPlant/motherPlantFragment.ts
+++ b/frontend/src/components/MotherPlant/motherPlantFragment.ts
@@ -19,15 +19,15 @@ export const motherPlantFragment = graphql(
       created
       modified
       plant_id
-      plant @include(if: $withPlant) {
+      plant @include(if: $MotherPlantWithPlant) {
         ...plantFragment
       }
       pollen_id
-      pollen @include(if: $withPollen) {
+      pollen @include(if: $MotherPlantWithPollen) {
         ...pollenFragment
       }
       crossing_id
-      crossing @include(if: $withCrossing) {
+      crossing @include(if: $MotherPlantWithCrossing) {
         ...crossingFragment
       }
     }

--- a/frontend/src/components/Orchard/OrchardModalEdit.vue
+++ b/frontend/src/components/Orchard/OrchardModalEdit.vue
@@ -48,11 +48,7 @@ defineProps<OrchardModalEditProps>();
 
 const insertMutation = graphql(
   `
-    mutation InsertOrchard(
-      $entity: orchards_insert_input!
-      $withPlantRows: Boolean = false
-      $withPlants: Boolean = false
-    ) {
+    mutation InsertOrchard($entity: orchards_insert_input!) {
       insert_orchards_one(object: $entity) {
         ...orchardFragment
       }
@@ -65,12 +61,7 @@ export type OrchardEditInsertMutation = typeof insertMutation;
 
 const editMutation = graphql(
   `
-    mutation UpdateOrchard(
-      $id: Int!
-      $entity: orchards_set_input!
-      $withPlantRows: Boolean = false
-      $withPlants: Boolean = false
-    ) {
+    mutation UpdateOrchard($id: Int!, $entity: orchards_set_input!) {
       update_orchards_by_pk(pk_columns: { id: $id }, _set: $entity) {
         ...orchardFragment
       }

--- a/frontend/src/components/Orchard/orchardFragment.ts
+++ b/frontend/src/components/Orchard/orchardFragment.ts
@@ -1,21 +1,13 @@
 import { graphql, type FragmentOf } from 'src/graphql';
-import { plantRowFragment } from '../PlantRow/plantRowFragment';
 
 export type OrchardFragment = FragmentOf<typeof orchardFragment>;
 
-export const orchardFragment = graphql(
-  `
-    fragment orchardFragment on orchards @_unmask {
-      id
-      name
-      disabled
-      created
-      modified
-      plant_rows(where: { disabled: { _eq: false } })
-        @include(if: $withPlantRows) {
-        ...plantRowFragment
-      }
-    }
-  `,
-  [plantRowFragment],
-);
+export const orchardFragment = graphql(`
+  fragment orchardFragment on orchards @_unmask {
+    id
+    name
+    disabled
+    created
+    modified
+  }
+`);

--- a/frontend/src/components/Plant/PlantModalEdit.vue
+++ b/frontend/src/components/Plant/PlantModalEdit.vue
@@ -59,8 +59,7 @@ const insertMutation = graphql(
   `
     mutation InsertPlant(
       $entity: plants_insert_input!
-      $withSegments: Boolean = true
-      $withAttributions: Boolean = false
+      $PlantWithSegments: Boolean = true
     ) {
       insert_plants_one(object: $entity) {
         ...plantFragment
@@ -75,8 +74,7 @@ const editMutation = graphql(
     mutation UpdatePlant(
       $id: Int!
       $entity: plants_set_input!
-      $withSegments: Boolean = true
-      $withAttributions: Boolean = false
+      $PlantWithSegments: Boolean = true
     ) {
       update_plants_by_pk(pk_columns: { id: $id }, _set: $entity) {
         ...plantFragment

--- a/frontend/src/components/Plant/PlantSelector.vue
+++ b/frontend/src/components/Plant/PlantSelector.vue
@@ -151,8 +151,7 @@ const query = graphql(
   `
     query PlantByLabelId(
       $where: plants_bool_exp!
-      $withSegments: Boolean = true
-      $withAttributions: Boolean = false
+      $PlantWithSegments: Boolean = true
     ) {
       plants(where: $where) {
         ...plantFragment

--- a/frontend/src/components/Plant/plantFragment.ts
+++ b/frontend/src/components/Plant/plantFragment.ts
@@ -1,5 +1,4 @@
 import { graphql, type FragmentOf } from 'src/graphql';
-import { entityAttributionsViewFragment } from 'src/components/Entity/entityAttributionsViewFragment';
 import { plantGroupSegmentsFragment } from '../PlantGroup/plantGroupFragment';
 
 export type PlantFragment = FragmentOf<typeof plantFragment>;
@@ -11,7 +10,7 @@ export const plantFragment = graphql(
       label_id
       cultivar_name
       plant_group_name
-      plant_group @include(if: $withSegments) {
+      plant_group @include(if: $PlantWithSegments) {
         ...plantGroupSegmentsFragment
       }
       serial_in_plant_row
@@ -42,10 +41,7 @@ export const plantFragment = graphql(
       disabled
       created
       modified
-      attributions_views @include(if: $withAttributions) {
-        ...entityAttributionsViewFragment
-      }
     }
   `,
-  [entityAttributionsViewFragment, plantGroupSegmentsFragment],
+  [plantGroupSegmentsFragment],
 );

--- a/frontend/src/components/PlantRow/PlantRowModalEdit.vue
+++ b/frontend/src/components/PlantRow/PlantRowModalEdit.vue
@@ -49,10 +49,7 @@ defineProps<PlantRowModalEditProps>();
 
 const insertMutation = graphql(
   `
-    mutation InsertPlantRow(
-      $entity: plant_rows_insert_input!
-      $withPlants: Boolean = false
-    ) {
+    mutation InsertPlantRow($entity: plant_rows_insert_input!) {
       insert_plant_rows_one(object: $entity) {
         ...plantRowFragment
       }
@@ -63,11 +60,7 @@ const insertMutation = graphql(
 
 const editMutation = graphql(
   `
-    mutation UpdatePlantRow(
-      $id: Int!
-      $entity: plant_rows_set_input!
-      $withPlants: Boolean = false
-    ) {
+    mutation UpdatePlantRow($id: Int!, $entity: plant_rows_set_input!) {
       update_plant_rows_by_pk(pk_columns: { id: $id }, _set: $entity) {
         ...plantRowFragment
       }

--- a/frontend/src/components/PlantRow/plantRowFragment.ts
+++ b/frontend/src/components/PlantRow/plantRowFragment.ts
@@ -16,13 +16,6 @@ export const plantRowFragment = graphql(
       }
       created
       modified
-      plants(where: { disabled: { _eq: false } }) @include(if: $withPlants) {
-        id
-        label_id
-        plant_group {
-          ...plantGroupSegmentsFragment
-        }
-      }
     }
   `,
   [plantGroupSegmentsFragment],

--- a/frontend/src/components/Pollen/PollenModalEdit.vue
+++ b/frontend/src/components/Pollen/PollenModalEdit.vue
@@ -53,9 +53,8 @@ const insertMutation = graphql(
   `
     mutation InsertPollen(
       $entity: pollen_insert_input!
-      $withCultivar: Boolean = false
-      $withMotherPlants: Boolean = false
-      $withLot: Boolean = false
+      $PollenWithCultivar: Boolean = false
+      $CultivarWithLot: Boolean = false
     ) {
       insert_pollen_one(object: $entity) {
         ...pollenFragment
@@ -72,9 +71,8 @@ const editMutation = graphql(
     mutation UpdatePollen(
       $id: Int!
       $entity: pollen_set_input!
-      $withCultivar: Boolean = false
-      $withMotherPlants: Boolean = false
-      $withLot: Boolean = false
+      $PollenWithCultivar: Boolean = false
+      $CultivarWithLot: Boolean = false
     ) {
       update_pollen_by_pk(pk_columns: { id: $id }, _set: $entity) {
         ...pollenFragment

--- a/frontend/src/components/Pollen/pollenFragment.ts
+++ b/frontend/src/components/Pollen/pollenFragment.ts
@@ -13,12 +13,8 @@ export const pollenFragment = graphql(
       created
       modified
       cultivar_id
-      cultivar @include(if: $withCultivar) {
+      cultivar @include(if: $PollenWithCultivar) {
         ...cultivarFragment
-      }
-      mother_plants @include(if: $withMotherPlants) {
-        id
-        name
       }
     }
   `,

--- a/frontend/src/pages/Crossings/EditModal.vue
+++ b/frontend/src/pages/Crossings/EditModal.vue
@@ -28,13 +28,7 @@ const props = defineProps<{ entityId: number | string }>();
 
 const query = graphql(
   `
-    query Crossing(
-      $id: Int!
-      $withParentCultivar: Boolean = false
-      $withLot: Boolean = false
-      $withLots: Boolean = false
-      $withMotherPlants: Boolean = false
-    ) {
+    query Crossing($id: Int!, $CultivarWithLot: Boolean = false) {
       crossings_by_pk(id: $id) {
         ...crossingFragment
       }

--- a/frontend/src/pages/Crossings/IndexPage.vue
+++ b/frontend/src/pages/Crossings/IndexPage.vue
@@ -26,6 +26,7 @@ import { useQueryArg } from 'src/composables/useQueryArg';
 import EntityContainer from 'src/components/Entity/EntityContainer.vue';
 import { crossingFragment } from 'src/components/Crossing/crossingFragment';
 import { useEntityIndexHooks } from 'src/composables/useEntityIndexHooks';
+import { cultivarFragment } from 'src/components/Cultivar/cultivarFragment';
 
 const { t, d } = useI18n();
 
@@ -36,10 +37,9 @@ const query = graphql(
       $offset: Int!
       $orderBy: [crossings_order_by!]
       $where: crossings_bool_exp
-      $withParentCultivar: Boolean = true
-      $withLot: Boolean = false
-      $withLots: Boolean = false
-      $withMotherPlants: Boolean = false
+      $CultivarWithLot: Boolean = false
+      $LotWithOrchard: Boolean = false
+      $LotWithCrossing: Boolean = false
     ) {
       crossings_aggregate {
         aggregate {
@@ -53,10 +53,16 @@ const query = graphql(
         order_by: $orderBy
       ) {
         ...crossingFragment
+        mother_cultivar {
+          ...cultivarFragment
+        }
+        father_cultivar {
+          ...cultivarFragment
+        }
       }
     }
   `,
-  [crossingFragment],
+  [crossingFragment, cultivarFragment],
 );
 
 const { search, pagination, variables } = useEntityIndexHooks<typeof query>();

--- a/frontend/src/pages/Crossings/ViewModal.vue
+++ b/frontend/src/pages/Crossings/ViewModal.vue
@@ -131,6 +131,9 @@ import EntityViewTableRow from 'src/components/Entity/View/EntityViewTableRow.vu
 import { localizeDate } from 'src/utils/dateUtils';
 import { useLocalizedSort } from 'src/composables/useLocalizedSort';
 import BaseNotFound from 'src/components/Base/BaseNotFound.vue';
+import { lotFragment } from 'src/components/Lot/lotFragment';
+import { motherPlantFragment } from 'src/components/MotherPlant/motherPlantFragment';
+import { cultivarFragment } from 'src/components/Cultivar/cultivarFragment';
 
 const props = defineProps<{ entityId: number | string }>();
 
@@ -138,17 +141,33 @@ const query = graphql(
   `
     query Crossing(
       $id: Int!
-      $withParentCultivar: Boolean = true
-      $withLot: Boolean = false
-      $withLots: Boolean = true
-      $withMotherPlants: Boolean = true
+      $CultivarWithLot: Boolean = false
+      $LotWithOrchard: Boolean = false
+      $LotWithCrossing: Boolean = false
+      $MotherPlantWithPlant: Boolean = false
+      $MotherPlantWithPollen: Boolean = false
+      $MotherPlantWithCrossing: Boolean = false
+      $PlantWithSegments: Boolean = false
+      $PollenWithCultivar: Boolean = false
     ) {
       crossings_by_pk(id: $id) {
         ...crossingFragment
+        lots {
+          ...lotFragment
+        }
+        mother_plants {
+          ...motherPlantFragment
+        }
+        mother_cultivar {
+          ...cultivarFragment
+        }
+        father_cultivar {
+          ...cultivarFragment
+        }
       }
     }
   `,
-  [crossingFragment],
+  [crossingFragment, lotFragment, motherPlantFragment, cultivarFragment],
 );
 
 const { data, error, fetching } = useQuery({

--- a/frontend/src/pages/Cultivars/EditModal.vue
+++ b/frontend/src/pages/Cultivars/EditModal.vue
@@ -28,7 +28,12 @@ const props = defineProps<{ entityId: number | string }>();
 
 const query = graphql(
   `
-    query Cultivar($id: Int!, $withLot: Boolean = false) {
+    query Cultivar(
+      $id: Int!
+      $CultivarWithLot: Boolean = false
+      $LotWithOrchard: Boolean = false
+      $LotWithCrossing: Boolean = false
+    ) {
       cultivars_by_pk(id: $id) {
         ...cultivarFragment
       }

--- a/frontend/src/pages/Cultivars/IndexPage.vue
+++ b/frontend/src/pages/Cultivars/IndexPage.vue
@@ -36,7 +36,9 @@ const query = graphql(
       $offset: Int!
       $orderBy: [cultivars_order_by!]
       $where: cultivars_bool_exp
-      $withLot: Boolean = true
+      $CultivarWithLot: Boolean = true
+      $LotWithOrchard: Boolean = false
+      $LotWithCrossing: Boolean = false
     ) {
       cultivars_aggregate {
         aggregate {

--- a/frontend/src/pages/Cultivars/ViewModal.vue
+++ b/frontend/src/pages/Cultivars/ViewModal.vue
@@ -88,7 +88,12 @@ const props = defineProps<{ entityId: number | string }>();
 
 const query = graphql(
   `
-    query Cultivar($id: Int!, $withLot: Boolean = true) {
+    query Cultivar(
+      $id: Int!
+      $CultivarWithLot: Boolean = true
+      $LotWithOrchard: Boolean = false
+      $LotWithCrossing: Boolean = false
+    ) {
       cultivars_by_pk(id: $id) {
         ...cultivarFragment
       }

--- a/frontend/src/pages/MotherPlants/EditModal.vue
+++ b/frontend/src/pages/MotherPlants/EditModal.vue
@@ -30,15 +30,14 @@ const query = graphql(
   `
     query MotherPlant(
       $id: Int!
-      $withPlant: Boolean = false
-      $withPollen: Boolean = false
-      $withCrossing: Boolean = false
-      $withParentCultivar: Boolean = false
-      $withCultivar: Boolean = false
-      $withMotherPlants: Boolean = false
-      $withSegments: Boolean = false
-      $withAttributions: Boolean = false
-      $withLot: Boolean = false
+      $MotherPlantWithPlant: Boolean = false
+      $MotherPlantWithPollen: Boolean = true
+      $MotherPlantWithCrossing: Boolean = false
+      $PollenWithCultivar: Boolean = false
+      $PlantWithSegments: Boolean = false
+      $CultivarWithLot: Boolean = false
+      $LotWithOrchard: Boolean = false
+      $LotWithCrossing: Boolean = false
     ) {
       mother_plants_by_pk(id: $id) {
         ...motherPlantFragment

--- a/frontend/src/pages/MotherPlants/IndexPage.vue
+++ b/frontend/src/pages/MotherPlants/IndexPage.vue
@@ -36,16 +36,14 @@ const query = graphql(
       $offset: Int!
       $orderBy: [mother_plants_order_by!]
       $where: mother_plants_bool_exp
-      $withPlant: Boolean = false
-      $withPollen: Boolean = false
-      $withCrossing: Boolean = false
-      $withParentCultivar: Boolean = false
-      $withCultivar: Boolean = false
-      $withMotherPlants: Boolean = false
-      $withSegments: Boolean = false
-      $withAttributions: Boolean = false
-      $withLot: Boolean = false
-      $withLots: Boolean = false
+      $MotherPlantWithPlant: Boolean = false
+      $MotherPlantWithCrossing: Boolean = false
+      $MotherPlantWithPollen: Boolean = false
+      $PollenWithCultivar: Boolean = false
+      $PlantWithSegments: Boolean = false
+      $CultivarWithLot: Boolean = false
+      $LotWithOrchard: Boolean = false
+      $LotWithCrossing: Boolean = false
     ) {
       mother_plants_aggregate {
         aggregate {

--- a/frontend/src/pages/MotherPlants/ViewModal.vue
+++ b/frontend/src/pages/MotherPlants/ViewModal.vue
@@ -130,16 +130,14 @@ const query = graphql(
   `
     query MotherPlant(
       $id: Int!
-      $withPlant: Boolean = true
-      $withPollen: Boolean = true
-      $withCrossing: Boolean = true
-      $withParentCultivar: Boolean = false
-      $withCultivar: Boolean = false
-      $withMotherPlants: Boolean = false
-      $withSegments: Boolean = false
-      $withAttributions: Boolean = false
-      $withLot: Boolean = false
-      $withLots: Boolean = false
+      $MotherPlantWithPlant: Boolean = true
+      $MotherPlantWithPollen: Boolean = true
+      $MotherPlantWithCrossing: Boolean = true
+      $PollenWithCultivar: Boolean = false
+      $PlantWithSegments: Boolean = false
+      $CultivarWithLot: Boolean = false
+      $LotWithOrchard: Boolean = false
+      $LotWithCrossing: Boolean = false
     ) {
       mother_plants_by_pk(id: $id) {
         ...motherPlantFragment

--- a/frontend/src/pages/Orchards/EditModal.vue
+++ b/frontend/src/pages/Orchards/EditModal.vue
@@ -28,11 +28,7 @@ const props = defineProps<{ entityId: number | string }>();
 
 const query = graphql(
   `
-    query Orchard(
-      $id: Int!
-      $withPlantRows: Boolean = false
-      $withPlants: Boolean = false
-    ) {
+    query Orchard($id: Int!) {
       orchards_by_pk(id: $id) {
         ...orchardFragment
       }

--- a/frontend/src/pages/Orchards/IndexPage.vue
+++ b/frontend/src/pages/Orchards/IndexPage.vue
@@ -38,8 +38,6 @@ const query = graphql(
       $offset: Int!
       $orderBy: [orchards_order_by!]
       $where: orchards_bool_exp
-      $withPlantRows: Boolean = false
-      $withPlants: Boolean = false
     ) {
       orchards_aggregate {
         aggregate {

--- a/frontend/src/pages/Orchards/ViewModal.vue
+++ b/frontend/src/pages/Orchards/ViewModal.vue
@@ -84,6 +84,7 @@ import { ResultOf, graphql } from 'src/graphql';
 import BaseSpinner from 'src/components/Base/BaseSpinner.vue';
 import { computed } from 'vue';
 import { orchardFragment } from 'src/components/Orchard/orchardFragment';
+import { plantRowFragment } from 'src/components/PlantRow/plantRowFragment';
 import { useI18n } from 'src/composables/useI18n';
 import { useRoute, useRouter } from 'vue-router';
 import EntityViewTable from 'src/components/Entity/View/EntityViewTable.vue';
@@ -96,17 +97,16 @@ const props = defineProps<{ entityId: number | string }>();
 
 const query = graphql(
   `
-    query Orchard(
-      $id: Int!
-      $withPlantRows: Boolean = true
-      $withPlants: Boolean = false
-    ) {
+    query Orchard($id: Int!) {
       orchards_by_pk(id: $id) {
         ...orchardFragment
+        plant_rows(where: { disabled: { _eq: false } }) {
+          ...plantRowFragment
+        }
       }
     }
   `,
-  [orchardFragment],
+  [orchardFragment, plantRowFragment],
 );
 
 const { data, error, fetching } = useQuery({

--- a/frontend/src/pages/PlantRows/EditModal.vue
+++ b/frontend/src/pages/PlantRows/EditModal.vue
@@ -28,7 +28,7 @@ const props = defineProps<{ entityId: number | string }>();
 
 const query = graphql(
   `
-    query PlantRow($id: Int!, $withPlants: Boolean = false) {
+    query PlantRow($id: Int!) {
       plant_rows_by_pk(id: $id) {
         ...plantRowFragment
       }

--- a/frontend/src/pages/PlantRows/IndexPage.vue
+++ b/frontend/src/pages/PlantRows/IndexPage.vue
@@ -38,7 +38,6 @@ const query = graphql(
       $offset: Int!
       $orderBy: [plant_rows_order_by!]
       $where: plant_rows_bool_exp
-      $withPlants: Boolean = false
     ) {
       plant_rows_aggregate {
         aggregate {

--- a/frontend/src/pages/PlantRows/ViewModal.vue
+++ b/frontend/src/pages/PlantRows/ViewModal.vue
@@ -113,18 +113,26 @@ import PlantLabelId from 'src/components/Plant/PlantLabelId.vue';
 import EntityName from 'src/components/Entity/EntityName.vue';
 import { useLocalizedSort } from 'src/composables/useLocalizedSort';
 import BaseNotFound from 'src/components/Base/BaseNotFound.vue';
+import { plantGroupSegmentsFragment } from 'src/components/PlantGroup/plantGroupFragment';
 
 const props = defineProps<{ entityId: number | string }>();
 
 const query = graphql(
   `
-    query PlantRow($id: Int!, $withPlants: Boolean = true) {
+    query PlantRow($id: Int!) {
       plant_rows_by_pk(id: $id) {
         ...plantRowFragment
+        plants(where: { disabled: { _eq: false } }) {
+          id
+          label_id
+          plant_group {
+            ...plantGroupSegmentsFragment
+          }
+        }
       }
     }
   `,
-  [plantRowFragment],
+  [plantRowFragment, plantGroupSegmentsFragment],
 );
 
 const { data, error, fetching } = useQuery({

--- a/frontend/src/pages/Plants/EditModal.vue
+++ b/frontend/src/pages/Plants/EditModal.vue
@@ -24,11 +24,7 @@ const props = defineProps<{ entityId: number | string }>();
 
 const query = graphql(
   `
-    query Plant(
-      $id: Int!
-      $withAttributions: Boolean = false
-      $withSegments: Boolean = true
-    ) {
+    query Plant($id: Int!, $PlantWithSegments: Boolean = true) {
       plants_by_pk(id: $id) {
         ...plantFragment
       }

--- a/frontend/src/pages/Plants/IndexPage.vue
+++ b/frontend/src/pages/Plants/IndexPage.vue
@@ -41,8 +41,7 @@ const query = graphql(
       $offset: Int!
       $orderBy: [plants_order_by!]
       $where: plants_bool_exp = { disabled: { _eq: false } }
-      $withAttributions: Boolean = false
-      $withSegments: Boolean = false
+      $PlantWithSegments: Boolean = false
     ) {
       plants_aggregate(where: $where) {
         aggregate {

--- a/frontend/src/pages/Plants/ViewModal.vue
+++ b/frontend/src/pages/Plants/ViewModal.vue
@@ -113,6 +113,7 @@ import {
   useRefreshAttributionsView,
 } from 'src/composables/useRefreshAttributionsView';
 import BaseNotFound from 'src/components/Base/BaseNotFound.vue';
+import { entityAttributionsViewFragment } from 'src/components/Entity/entityAttributionsViewFragment';
 
 const props = defineProps<{ entityId: number | string }>();
 
@@ -125,17 +126,16 @@ const {
 
 const query = graphql(
   `
-    query Plant(
-      $id: Int!
-      $withAttributions: Boolean = true
-      $withSegments: Boolean = true
-    ) {
+    query Plant($id: Int!, $PlantWithSegments: Boolean = true) {
       plants_by_pk(id: $id) {
         ...plantFragment
+        attributions_views {
+          ...entityAttributionsViewFragment
+        }
       }
     }
   `,
-  [plantFragment],
+  [plantFragment, entityAttributionsViewFragment],
 );
 
 const {

--- a/frontend/src/pages/Pollen/EditModal.vue
+++ b/frontend/src/pages/Pollen/EditModal.vue
@@ -30,9 +30,8 @@ const query = graphql(
   `
     query Pollen(
       $id: Int!
-      $withCultivar: Boolean = false
-      $withMotherPlants: Boolean = false
-      $withLot: Boolean = false
+      $PollenWithCultivar: Boolean = false
+      $CultivarWithLot: Boolean = false
     ) {
       pollen_by_pk(id: $id) {
         ...pollenFragment

--- a/frontend/src/pages/Pollen/IndexPage.vue
+++ b/frontend/src/pages/Pollen/IndexPage.vue
@@ -37,9 +37,10 @@ const query = graphql(
       $offset: Int!
       $orderBy: [pollen_order_by!]
       $where: pollen_bool_exp
-      $withCultivar: Boolean = true
-      $withMotherPlants: Boolean = false
-      $withLot: Boolean = false
+      $PollenWithCultivar: Boolean = true
+      $CultivarWithLot: Boolean = false
+      $LotWithOrchard: Boolean = false
+      $LotWithCrossing: Boolean = false
     ) {
       pollen_aggregate {
         aggregate {

--- a/frontend/src/pages/Pollen/ViewModal.vue
+++ b/frontend/src/pages/Pollen/ViewModal.vue
@@ -106,12 +106,17 @@ const query = graphql(
   `
     query Pollen(
       $id: Int!
-      $withCultivar: Boolean = true
-      $withMotherPlants: Boolean = false
-      $withLot: Boolean = false
+      $PollenWithCultivar: Boolean = true
+      $CultivarWithLot: Boolean = false
+      $LotWithOrchard: Boolean = false
+      $LotWithCrossing: Boolean = false
     ) {
       pollen_by_pk(id: $id) {
         ...pollenFragment
+        mother_plants {
+          id
+          name
+        }
       }
     }
   `,


### PR DESCRIPTION
This PR essentially does the following things:

- **Prefix all includes in fragments** with the fragment name: e.g. to include the `lot` in the `cultivar` fragment, we must set `$CultivarWithLot = true`.
- **Limit fragment includes to \*:1 associations** to simplify things and prevent circular fragment references: e.g. the `cultivar` fragment includes `lot` but not `plant_groups`.
- **Prevent circular includes** by removing `mother_variety` and `father_variety` from the `crossings` fragment.