### PR TITLE
[FIX] default sort attributions date desc

### DIFF
--- a/frontend/src/pages/Attributions/IndexPage.vue
+++ b/frontend/src/pages/Attributions/IndexPage.vue
@@ -171,6 +171,7 @@ const {
   variables: _variables,
 } = useEntityIndexHooks<typeof query>({
   defaultSortBy: 'created',
+  defaultSortOrderDesc: true,
   searchColumns: searchColumns,
 });
 


### PR DESCRIPTION
Sort by date `desc` so that my last attribution is the first in the table.
<img width="1346" alt="Screenshot 2024-09-03 at 15 11 29" src="https://github.com/user-attachments/assets/1d2b3313-8a99-46d5-bcbe-5710860b6a49">
