### PR TITLE
[FIX] graphql error when saving attribution text input with empty string

### DIFF
--- a/frontend/src/components/Attribution/Add/AttributionAddFormInput.vue
+++ b/frontend/src/components/Attribution/Add/AttributionAddFormInput.vue
@@ -38,6 +38,12 @@
       ref="textInputRef"
       :model-value="modelValue?.text_value ?? null"
       :validation="{ maxLen: 2047, pattern: null }"
+      :additional-rules="[
+        (value: string | null) =>
+          (!textNote && !photoNote) ||
+          (value !== '' && value !== null) ||
+          t('attributions.add.notesMustHaveValue'),
+      ]"
       @update:model-value="
         (val: string | null) => updateModelValue({ text_value: val })
       "

--- a/frontend/src/components/Attribution/Add/AttributionAddFormInputText.vue
+++ b/frontend/src/components/Attribution/Add/AttributionAddFormInputText.vue
@@ -18,7 +18,9 @@
         value === null ||
         isValidString({ value, validation }) ||
         t('base.validation.maxLen', { x: validation.maxLen }),
+      ...(props.additionalRules ?? []),
     ]"
+    @blur="modelValue === '' && (modelValue = null)"
   />
 </template>
 <script setup lang="ts">
@@ -31,6 +33,7 @@ import { focusInView } from 'src/utils/focusInView';
 
 export interface AttributionAddFormInputProps {
   validation: { maxLen: number | null; pattern: string | null };
+  additionalRules?: QInput['rules'];
 }
 
 const props = defineProps<AttributionAddFormInputProps>();

--- a/frontend/src/i18n/en-US/attributions.ts
+++ b/frontend/src/i18n/en-US/attributions.ts
@@ -81,6 +81,8 @@ export const attributions = {
 
     clearAttribute:
       'Clearing this value will remove the comments for this attribute as well. Do you want to delete the comments?',
+    notesMustHaveValue:
+      'Add a value or remove the note / photo for this attribute.',
 
     saved: 'Attribute saved.',
     uploading: 'Saving… {percentage}%',


### PR DESCRIPTION
Without this fix, adding some text to an attribution text input and removing the input value again using `backspace` or `delete` instead of the clean icon, results in a graphql error on save.