### PR TITLE
[FIX] missing entity after switch from attribution edit

### DIFF
--- a/frontend/src/components/Attribution/Add/AttributionAddSteps.vue
+++ b/frontend/src/components/Attribution/Add/AttributionAddSteps.vue
@@ -291,6 +291,11 @@ function getInitialStep() {
 }
 
 const step = ref(getInitialStep());
+watch(step, (s) => {
+  if (s === 3) {
+    editAttributionId.value = null;
+  }
+});
 
 function onAfterTransition(to: string | number) {
   if (to === 3) {


### PR DESCRIPTION
switching to entity selector while editing an attribution did not reset the `editAttributionId`  and therefore yielded in a missing entity if the same entity was picked again.