### PR TITLE
Misc fixes

### DIFF
--- a/frontend/src/components/Attribute/AttributeEntityForm.vue
+++ b/frontend/src/components/Attribute/AttributeEntityForm.vue
@@ -111,7 +111,6 @@ const emits = defineEmits<{
 // for defineExpose() see below
 
 const initialData = {
-  id: 'id' in props.attribute ? props.attribute.id : undefined,
   name: props.attribute.name,
   validation_rule: props.attribute.validation_rule,
   data_type: props.attribute.data_type,

--- a/frontend/src/components/Entity/Edit/EntitySelect.vue
+++ b/frontend/src/components/Entity/Edit/EntitySelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <BaseInputLabel ref="label" :label="label" :explainer="explainer">
+  <BaseInputLabel ref="labelRef" :label="label" :explainer="explainer">
     <template v-if="$slots.explainer" #explainer>
       <slot name="explainer"></slot>
     </template>
@@ -168,6 +168,7 @@ function filterOptions(
 
 const selectRef = ref<QSelect | null>(null);
 const labelRef = ref<InstanceType<typeof BaseInputLabel> | null>(null);
+const labelEl = computed(() => labelRef.value?.$el);
 defineExpose({
   validate: () => selectRef.value?.validate(),
   focus: () => selectRef.value && focusInView(selectRef.value),
@@ -176,7 +177,7 @@ defineExpose({
     selectRef.value?.updateInputValue(value, noFilter),
   hidePopup: () => selectRef.value?.hidePopup(),
   blur: () => selectRef.value?.blur(),
-  $el: labelRef.value?.$el,
+  $el: labelEl,
 });
 
 const { inputBgColor } = useInputBackground();

--- a/frontend/src/components/Entity/EntityModalEdit.vue
+++ b/frontend/src/components/Entity/EntityModalEdit.vue
@@ -294,8 +294,11 @@ function createSaveThen(...actions: (() => Promise<void> | void)[]) {
         await action();
       }
     } catch (e) {
-      // ignore. errors must be handled in the actions
-      // promises are just used to chain the actions
+      // errors must be handled in the actions
+      // promises are just used to chain the actions.
+      // but report any unhandled errors
+      console.error('Failed to save and execute actions', e);
+      captureException(e);
     }
   };
 }

--- a/frontend/src/components/Entity/EntityModalEdit.vue
+++ b/frontend/src/components/Entity/EntityModalEdit.vue
@@ -15,6 +15,7 @@
     :save-then-print="!!makeLabel"
     v-on="{
       save: createSaveThen(close),
+      keydown: onKeydown,
       cancel,
       resetErrors,
       ...(makeLabel && { saveThenPrint: createSaveThen(printLabel, close) }),
@@ -297,6 +298,13 @@ function createSaveThen(...actions: (() => Promise<void> | void)[]) {
       // promises are just used to chain the actions
     }
   };
+}
+
+function onKeydown(event: KeyboardEvent) {
+  // prevent arrow keys from navigating the page when editing
+  if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+    event.stopPropagation();
+  }
 }
 
 const { t } = useI18n();

--- a/frontend/src/composables/useEntityForm.ts
+++ b/frontend/src/composables/useEntityForm.ts
@@ -1,4 +1,5 @@
 import { computed, type Ref, type VNodeRef } from 'vue';
+import { is } from 'quasar';
 
 export type InputRef = VNodeRef & {
   validate: () => boolean | Promise<boolean> | undefined;
@@ -15,11 +16,7 @@ export function useEntityForm<T extends Record<string, unknown>>({
   data: Ref<T>;
   initialData: T;
 }) {
-  const isDirty = computed(() => {
-    return (Object.keys(initialData) as (keyof typeof initialData)[]).some(
-      (key) => data.value[key] !== initialData[key],
-    );
-  });
+  const isDirty = computed(() => !is.deepEqual(data.value, initialData));
 
   async function validate() {
     const validated = await Promise.all(

--- a/frontend/src/pages/Cultivars/AddModal.vue
+++ b/frontend/src/pages/Cultivars/AddModal.vue
@@ -4,7 +4,7 @@
       v-if="cultivar"
       :cultivar="cultivar"
       :title="t('base.new')"
-      :is-variety="false"
+      :is-variety="data?.cultivars_by_pk?.is_variety ?? false"
     />
   </EntityFetchWrapper>
 </template>


### PR DESCRIPTION
- fix attribute edit graphql error
- prevent arrow key navigation in edit modals
- fix accidential modal closing prevention (for forms with non-primitve input values)
- fix `scrollIntoView` on select inputs
- fix cultivar's `save & new` not respecting `is_variety`
- report discarded errors in save action chain in entity modal edit